### PR TITLE
[#8] 에러가 발생했을 때 오류 수정

### DIFF
--- a/src/components/Reserve/ReserveSubmit.tsx
+++ b/src/components/Reserve/ReserveSubmit.tsx
@@ -72,7 +72,7 @@ const ReserveSubmit = () => {
         representative ? 'REPRESENTATIVE' : 'DEFAULT',
       );
       if (data.hasOwnProperty('error') || data.hasOwnProperty('errors')) {
-        alertError(data.error);
+        alertError(data.message);
       } else {
         setReserveId(!isUpdatePage ? data.reserveId : visitors[0].reserveId);
         setIsOpen(true);

--- a/src/tools/API/baseAPI.ts
+++ b/src/tools/API/baseAPI.ts
@@ -28,7 +28,7 @@ const baseAPI = async <T = any>(method: httpMethod, path: string, data: Object =
     });
     return response;
   } catch {
-    return { data: { error: { message: ERROR_MESSAGE } } };
+    return { data: { message: ERROR_MESSAGE } };
   }
 };
 


### PR DESCRIPTION
- 이전에는 에러가 발생했을 때 data.error.message 객체에 에러 관련 문구가
  저장되어있었는데, data.message로 에러 관련 문구 이동되어 그에 맞게
  수정함